### PR TITLE
TBD: Element loading control

### DIFF
--- a/index-react.html
+++ b/index-react.html
@@ -114,8 +114,11 @@ class App extends preact.Component {
           alt="preact img"
           srcSet="https://raw.githubusercontent.com/preactjs/preact/8b0bcc927995c188eca83cba30fbc83491cc0b2f/logo.svg?sanitize=true 100w"
           style={{width: '300px', height: '90px'}}
+          aria-label={this.state.aria || 'IMG1'}
           >
         </AmpImg>
+
+        <button onClick={() => this.setState({aria: 'IMG1 updated'})}>Update aria</button>
 
         <AmpCarousel
           id="c1"

--- a/src/amp-react-img.js
+++ b/src/amp-react-img.js
@@ -18,7 +18,7 @@ import ReactCompatibleBaseElement from './react-compat-base-element.js';
 import {
   AmpContext,
 } from './amp-context.js';
-import { useHasEverLoaded } from './amp-react-utils.js';
+import { exporter, useHasEverLoaded } from './amp-react-utils.js';
 
 const {
   useLayoutEffect,
@@ -70,7 +70,7 @@ export function AmpImg(props) {
     const loadPromise = new Promise(resolve => {
       img.onload = resolve;
     });
-    // TBD: export load promise.
+    exporter(props, {loadPromise});
   }, [attrs.src, attrs.srcSet]);
 
   return preact.createElement('img', attrs);

--- a/src/amp-react-img.js
+++ b/src/amp-react-img.js
@@ -20,6 +20,11 @@ import {
 } from './amp-context.js';
 import { useHasEverLoaded } from './amp-react-utils.js';
 
+const {
+  useLayoutEffect,
+  useRef,
+} = preactHooks;
+
 /**
  * @return {boolean}
  */
@@ -48,7 +53,8 @@ function guaranteeSrcForSrcsetUnsupportedBrowsers(props) {
  */
 export function AmpImg(props) {
   const renderable = useHasEverLoaded();
-  const attrs = {...props};
+  const imageRef = useRef();
+  const attrs = {...props, ref: imageRef};
 
   attrs['decoding'] = 'async';
 
@@ -58,6 +64,14 @@ export function AmpImg(props) {
     delete attrs['src'];
     delete attrs['srcSet'];
   }
+
+  useLayoutEffect(props, () => {
+    const img = imageRef.current;
+    const loadPromise = new Promise(resolve => {
+      img.onload = resolve;
+    });
+    // TBD: export load promise.
+  }, [attrs.src, attrs.srcSet]);
 
   return preact.createElement('img', attrs);
 }

--- a/src/amp-react-img.js
+++ b/src/amp-react-img.js
@@ -65,7 +65,7 @@ export function AmpImg(props) {
     delete attrs['srcSet'];
   }
 
-  useLayoutEffect(props, () => {
+  useLayoutEffect(() => {
     const img = imageRef.current;
     const loadPromise = new Promise(resolve => {
       img.onload = resolve;

--- a/src/amp-react-utils.js
+++ b/src/amp-react-utils.js
@@ -24,17 +24,6 @@ const {
 } = preactHooks;
 
 
-export function cleanProps(props) {
-  const clean = {};
-  for (const k in props) {
-    if (k[0] != '_') {
-      clean[k] = props[k];
-    }
-  }
-  return clean;
-}
-
-
 /**
  * Experimental hook to sync a state based on a property. The state is:
  * - Initialized from the property;

--- a/src/amp-react-utils.js
+++ b/src/amp-react-utils.js
@@ -17,10 +17,22 @@
 import { AmpContext } from './amp-context.js';
 const {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useContext,
 } = preactHooks;
+
+
+export function cleanProps(props) {
+  const clean = {};
+  for (const k in props) {
+    if (k[0] != '_') {
+      clean[k] = props[k];
+    }
+  }
+  return clean;
+}
 
 
 /**
@@ -49,6 +61,36 @@ export function useStateFromProp(prop) {
     }];
 }
 
+
+/**
+ * @param {!Object} props
+ * @param {!Object} exports
+ */
+export function exporter(props, exports) {
+  const func = props['_exporter'];
+  if (func) {
+    func(exports);
+  }
+}
+
+
+/**
+ * @param {!Object} props
+ * @param {function():Promise} effect
+ */
+export function useLoadEffect(props, effect) {
+  // TBD: combine with a recursive AmpContext.renderable?
+  // See https://github.com/jridgewell/amp-react/pull/6
+  // const ampContext = useContext(AmpContext);
+  // return ampContext.renderable && props.load != 'manual';
+  const toLoad = props['_load'] != 'manual';
+  useLayoutEffect(() => {
+    if (toLoad) {
+      const result = effect();
+      exporter(props, {loadPromise: Promise.resolve(result)});
+    }
+  }, [toLoad]);
+}
 
 /**
  * @param {!Element} elementRef


### PR DESCRIPTION
An alternative is exporting state using forwardRef. See https://github.com/jridgewell/amp-react/blob/master/video-react.html#L101 for an example.

This is both an additional and alternative to https://github.com/jridgewell/amp-react/pull/6.

This PR fixes React case and makes it more equivalent to the AMP and vice-versa.

Some key notes:

1. The loading (both prerendering and normal loading) is controlled by a single AMP-specific prop `_load`. The possible values are `auto` and `manual`. Default is `auto` indicating immediate load. But AMP always starts with `manual`.
2. Whether prerendering or normal rendering, AMP will change `_load` to `auto` whenever rendering time has arrived. For loading promise, see exports below.
3. The `useLoadEffect` hook does all necessary steps for rendering: checks the properties, executes the loading function, re-exports loading promise.
4. The exports system is a little funky. Its goal is to simply call the `_exporter` callback in properties with the updated "public" state. AMP element configures itself as an exporter. It merges the exported values and manages them on AMP compat level. This is how loading promise is returned from the `layoutCallback`.
5. The `load = auto` can be easily combined with the `AmpContext.renderable` from https://github.com/jridgewell/amp-react/pull/6. Not sure if there's a value from this independently of AMP Runtime. AMP Runtime can easily computed context into a combined `load` value. But this could also be useful in React, e.g. automatic loading management.

The alternative would be to redo everything via `AmpContext.renderable` context. However, I have some doubts about that. I feel like `AmpContext.renderable` and `load=auto` are somewhat independent. An area of DOM is either renderable or not. But loading is managed by scheduler. By default only elements in the renderable subtrees are loaded. But being renderable does not guarantee that the element/component will immediately load - the scheduler is in charge of that.

Also, on the structural level: renderable is more like `buildCallback` and loading is `layoutCallback`. I.e. an element could be fully rendered to save on DOM relayouts later, but not yet loaded to save on CPU/network bandwidth.
